### PR TITLE
When populating EClasses from Concepts, if there are implementing concept an exception occurs

### DIFF
--- a/emf/src/main/java/io/lionweb/lioncore/java/emf/EMFMetamodelExporter.java
+++ b/emf/src/main/java/io/lionweb/lioncore/java/emf/EMFMetamodelExporter.java
@@ -146,7 +146,9 @@ public class EMFMetamodelExporter extends AbstractEMFExporter {
         .getImplemented()
         .forEach(
             implemented -> {
-              throw new UnsupportedOperationException();
+              EClass implementedEClass =
+                      (EClass) conceptsToEClassesMapping.getCorrespondingEClass(implemented);
+              eClass.getESuperTypes().add(implementedEClass);
             });
 
     concept


### PR DESCRIPTION
Adjusted code to map implemented classes to EClasses and add them to the superTypes of the EClass in question.